### PR TITLE
Move web app to main bot, not just Slack

### DIFF
--- a/alphabot/app.py
+++ b/alphabot/app.py
@@ -45,7 +45,7 @@ parser.add_argument('-e', '--engine', dest='engine', action='store',
 parser.add_argument('-m', '--memory', dest='memory', action='store',
                     default='dict', help='What persistent storage to use.')
 
-parser.add_argument('--no-web-app', dest='start_web_app', action='store_true',
+parser.add_argument('--no-web-app', dest='no_start_web_app', action='store_true',
                     default=False, help='Run a web server?')
 
 args = parser.parse_args()
@@ -65,8 +65,8 @@ def start_ioloop():
 
 @gen.coroutine
 def start_alphabot():
-
-    bot = alphabot.bot.get_instance(engine=args.engine, start_web_app=args.start_web_app)
+    start_web_app = not args.no_start_web_app
+    bot = alphabot.bot.get_instance(engine=args.engine, start_web_app=start_web_app)
     memory = args.memory
 
     full_path_scripts = [os.path.abspath(s) for s in args.scripts]

--- a/alphabot/app.py
+++ b/alphabot/app.py
@@ -45,6 +45,9 @@ parser.add_argument('-e', '--engine', dest='engine', action='store',
 parser.add_argument('-m', '--memory', dest='memory', action='store',
                     default='dict', help='What persistent storage to use.')
 
+parser.add_argument('--web_app', dest='start_web_app', action='store_true',
+                    default=False, help='Run a web server?')
+
 args = parser.parse_args()
 
 __author__ = ('Mikhail Simin <mikhail@nextdoor.com>',)
@@ -63,7 +66,7 @@ def start_ioloop():
 @gen.coroutine
 def start_alphabot():
 
-    bot = alphabot.bot.get_instance(engine=args.engine)
+    bot = alphabot.bot.get_instance(engine=args.engine, start_web_app=args.start_web_app)
     memory = args.memory
 
     full_path_scripts = [os.path.abspath(s) for s in args.scripts]

--- a/alphabot/app.py
+++ b/alphabot/app.py
@@ -45,8 +45,8 @@ parser.add_argument('-e', '--engine', dest='engine', action='store',
 parser.add_argument('-m', '--memory', dest='memory', action='store',
                     default='dict', help='What persistent storage to use.')
 
-parser.add_argument('--web_app', dest='start_web_app', action='store_true',
-                    default=False, help='Run a web server?')
+parser.add_argument('--no_web_app', dest='start_web_app', action='store_false',
+                    default=True, help='Run a web server?')
 
 args = parser.parse_args()
 

--- a/alphabot/app.py
+++ b/alphabot/app.py
@@ -45,8 +45,9 @@ parser.add_argument('-e', '--engine', dest='engine', action='store',
 parser.add_argument('-m', '--memory', dest='memory', action='store',
                     default='dict', help='What persistent storage to use.')
 
-parser.add_argument('--no-web-app', dest='no_start_web_app', action='store_true',
-                    default=False, help='Run a web server?')
+# NOTE: Since the variable is start_web_app, it does actually default True.
+parser.add_argument('--no-web-app', dest='start_web_app', action='store_false',
+                    default=True, help='Do not run the web server.')
 
 args = parser.parse_args()
 
@@ -65,8 +66,7 @@ def start_ioloop():
 
 @gen.coroutine
 def start_alphabot():
-    start_web_app = not args.no_start_web_app
-    bot = alphabot.bot.get_instance(engine=args.engine, start_web_app=start_web_app)
+    bot = alphabot.bot.get_instance(engine=args.engine, start_web_app=args.start_web_app)
     memory = args.memory
 
     full_path_scripts = [os.path.abspath(s) for s in args.scripts]

--- a/alphabot/app.py
+++ b/alphabot/app.py
@@ -45,8 +45,8 @@ parser.add_argument('-e', '--engine', dest='engine', action='store',
 parser.add_argument('-m', '--memory', dest='memory', action='store',
                     default='dict', help='What persistent storage to use.')
 
-parser.add_argument('--no_web_app', dest='start_web_app', action='store_false',
-                    default=True, help='Run a web server?')
+parser.add_argument('--no-web-app', dest='start_web_app', action='store_true',
+                    default=False, help='Run a web server?')
 
 args = parser.parse_args()
 

--- a/alphabot/default-scripts/slack_specific.py
+++ b/alphabot/default-scripts/slack_specific.py
@@ -10,9 +10,6 @@ import alphabot.bot
 bot = alphabot.bot.get_instance()
 log = logging.getLogger(__name__)
 
-WEB_PORT = int(os.getenv('WEB_PORT', 8000))
-WEB_PORT_SSL = int(os.getenv('WEB_PORT_SSL', 8443))
-
 
 @bot.on(ok=False, error={"code": -1,
                          "msg": "slow down, too many messages..."})

--- a/alphabot/default-scripts/slack_specific.py
+++ b/alphabot/default-scripts/slack_specific.py
@@ -10,8 +10,8 @@ import alphabot.bot
 bot = alphabot.bot.get_instance()
 log = logging.getLogger(__name__)
 
-SLACK_PORT = int(os.getenv('SLACK_PORT', 8000))
-SLACK_PORT_SSL = int(os.getenv('SLACK_PORT_SSL', 8443))
+WEB_PORT = int(os.getenv('WEB_PORT', 8000))
+WEB_PORT_SSL = int(os.getenv('WEB_PORT_SSL', 8443))
 
 
 @bot.on(ok=False, error={"code": -1,
@@ -20,12 +20,6 @@ SLACK_PORT_SSL = int(os.getenv('SLACK_PORT_SSL', 8443))
 def slack_throttle(event):
     log.warning('Detected a slow-down warning!')
     bot._too_fast_warning = True
-
-
-class HealthCheck(web.RequestHandler):
-
-    def get(self):
-        self.write('ok')
 
 
 class SlackButtonAction(web.RequestHandler):
@@ -61,16 +55,10 @@ class SlackButtonAction(web.RequestHandler):
 
 @bot.on_start
 @gen.coroutine
-def start_webapp():
-    log.info('Creating a web app')
-    app = web.Application([
-        (r'/healthz', HealthCheck),
-        (r'/slack-button-action', SlackButtonAction)
-    ])
-
-    log.info('Listening on port %s' % SLACK_PORT)
-    app.listen(SLACK_PORT)
-    app.listen(SLACK_PORT_SSL, ssl_options={
-        "certfile": "/tmp/alphabot.pem",  # Generate these in your entrypoint
-        "keyfile": "/tmp/alphabot.key"
-    })
+def add_handlers():
+    """Adds Slack specific handlers to the Bot's web_app."""
+    log.info('Adding slack handlers')
+    try:
+        bot.add_web_handler(r'/slack-button-action', SlackButtonAction)
+    except alphabot.bot.WebApplicationNotAvailable:
+        log.error('Unable to add slack callback.')

--- a/alphabot/tests/test_bot.py
+++ b/alphabot/tests/test_bot.py
@@ -12,6 +12,17 @@ class TestException(Exception):
     """Unique exception to be used during testing."""
 
 
+class TestWebApp(testing.AsyncHTTPTestCase):
+    def get_app(self):
+        bot = AB.get_instance(start_web_app=True)
+        return bot.make_web_app()
+
+    def test_healthz(self):
+        response = self.fetch('/healthz')
+        self.assertEqual(response.code, 200)
+        self.assertEqual(response.body, 'ok')
+
+
 class TestBot(testing.AsyncTestCase):
 
     @testing.gen_test


### PR DESCRIPTION
Allows 'scripts' to add on to the `web.Application` (by moving the web application out of the Slack specific scripts).